### PR TITLE
Multiple page requests disabled

### DIFF
--- a/src/components/common/AdCardList.tsx
+++ b/src/components/common/AdCardList.tsx
@@ -6,6 +6,7 @@ import { borderColor } from "@mui/system";
 
 interface AdCardData {
   pageNumber: number;
+  isLoading: boolean;
   recieveDataFromAdCardListChild;
   apiData;
 }
@@ -38,7 +39,7 @@ const AdCardList = (props: AdCardData) => {
               variant="secondary"
               size="sm"
               onClick={(e) =>
-                props.pageNumber !== 1
+                props.pageNumber !== 1 && !props.isLoading
                   ? props.recieveDataFromAdCardListChild(props.pageNumber - 1)
                   : null
               }
@@ -48,7 +49,7 @@ const AdCardList = (props: AdCardData) => {
             <Button
               variant="secondary"
               size="sm"
-              onClick={(e) => props.recieveDataFromAdCardListChild(1)}
+              onClick={(e) => !props.isLoading ? props.recieveDataFromAdCardListChild(1) : null}
             >
               1
             </Button>{" "}
@@ -67,8 +68,8 @@ const AdCardList = (props: AdCardData) => {
             <Button
               variant="secondary"
               size="sm"
-              onClick={(e) =>
-                props.recieveDataFromAdCardListChild(props.pageNumber + 1)
+              onClick={(e) => !props.isLoading ?
+                props.recieveDataFromAdCardListChild(props.pageNumber + 1) : null
               }
             >
               Nästa

--- a/src/components/public/Home.tsx
+++ b/src/components/public/Home.tsx
@@ -17,7 +17,7 @@ const Home = () => {
     setCurrentPage(page);
   };
 
-  // Fetch
+  // Fetch current count of ads in the DB
   const fetchAdCount = () => {
     const API = "http://82.102.1.109/api/joblistings/count";
     fetch(API)
@@ -26,7 +26,8 @@ const Home = () => {
       .catch((err) => console.error(err));
   };
 
-  const fetchSearchData = async () => {
+  //
+  const fetchLatestAds = async () => {
     setIsLoading(true);
     const API = "http://82.102.1.109/api/joblistings/javascript/" + currentPage;
     await fetch(API)
@@ -38,7 +39,7 @@ const Home = () => {
 
   useEffect(() => {
     fetchAdCount();
-    fetchSearchData();
+    fetchLatestAds();
   }, [currentPage]);
 
   return (
@@ -69,6 +70,7 @@ const Home = () => {
               apiData={latestAdApiData}
               pageNumber={currentPage}
               recieveDataFromAdCardListChild={recieveDataFromAdCardListChild}
+              isLoading={isLoading}
             />
           </Col>
         </Row>


### PR DESCRIPTION
Fixed a issue were you could spam the previously/next button and request multiple fetches from backend and "delay" the page change. Should not be possible to request another page change while a fetch is going.