### PR TITLE
Big major lifechanging patch

### DIFF
--- a/src/components/common/AdCardList.tsx
+++ b/src/components/common/AdCardList.tsx
@@ -200,17 +200,17 @@ const AdCardList = (props: AdCardData) => {
                     <Button variant="primary" size="sm">
                       {props.pageNumber}
                     </Button>{" "}
-                    <Button variant="secondary" size="sm">
+                    <Button variant="secondary" size="sm" onClick={(e) => props.recieveDataFromAdCardListChild(props.pageNumber + 1)}>
                       {props.pageNumber + 1}
                     </Button>{" "}
-                    <Button variant="secondary" size="sm">
+                    <Button variant="secondary" size="sm" onClick={(e) => props.recieveDataFromAdCardListChild(props.pageNumber + 2)}>
                       {props.pageNumber + 2}
                     </Button>{" "}
-                    <Button variant="secondary" size="sm">
+                    <Button variant="secondary" size="sm" onClick={(e) => props.recieveDataFromAdCardListChild(props.pageNumber + 3)}>
                       {props.pageNumber + 3}
                     </Button>{" "}
                     {props.pageNumber === 1 ? (
-                      <Button variant="secondary" size="sm">
+                      <Button variant="secondary" size="sm" onClick={(e) => props.recieveDataFromAdCardListChild(props.pageNumber + 4)}>
                         {props.pageNumber + 4}
                       </Button>
                     ) : null}{" "}

--- a/src/components/common/AdCardList.tsx
+++ b/src/components/common/AdCardList.tsx
@@ -144,6 +144,22 @@ const AdCardList = (props: AdCardData) => {
           <Row>
             {props.isWatchingAdSection ? (
               <div>
+                <Row style={{textAlign:"right", paddingRight:"1.3rem"}}>
+                <Col>
+                <span style={{fontSize:"11px"}}>Antal annonser per sida</span>
+                    <DropdownButton
+                      size="sm"
+                      id="dropdown-basic-button"
+                      variant="secondary"
+                      title={pageSize}
+                      onSelect={(e) => setPageSize(e)}
+                    >
+                      <Dropdown.Item eventKey="5">5</Dropdown.Item>
+                      <Dropdown.Item eventKey="10">10</Dropdown.Item>
+                      <Dropdown.Item eventKey="20">20</Dropdown.Item>
+                    </DropdownButton>
+                  </Col>
+                </Row>
                 <Accordion flush>
                   {props.apiData === null
                     ? null
@@ -158,7 +174,7 @@ const AdCardList = (props: AdCardData) => {
                       )}
                 </Accordion>
                 <Row style={{ textAlign: "center", paddingTop: "1rem" }}>
-                  <Col sm={11}>
+                  <Col sm={12}>
                     <Button
                       variant="secondary"
                       size="sm"
@@ -211,19 +227,6 @@ const AdCardList = (props: AdCardData) => {
                     >
                       Nästa
                     </Button>{" "}
-                  </Col>
-                  <Col sm={1}>
-                    <DropdownButton
-                      size="sm"
-                      id="dropdown-basic-button"
-                      variant="secondary"
-                      title={pageSize}
-                      onSelect={(e) => setPageSize(e)}
-                    >
-                      <Dropdown.Item eventKey="5">5</Dropdown.Item>
-                      <Dropdown.Item eventKey="10">10</Dropdown.Item>
-                      <Dropdown.Item eventKey="20">20</Dropdown.Item>
-                    </DropdownButton>
                   </Col>
                 </Row>
               </div>

--- a/src/components/common/AdCardList.tsx
+++ b/src/components/common/AdCardList.tsx
@@ -22,12 +22,13 @@ interface AdCardData {
   apiData: any;
   isSearching: boolean;
   isLoading: boolean;
-  savedAdCounter: any;
-  searchBarText: string;
+  savedAdCounter: any ;
+  searchTerm: string;
+  searchCount: number;
 }
 
 const AdCardList = (props: AdCardData) => {
-  const [pageSize, setPageSize] = useState<string | null>("5");
+  const [pageSize, setPageSize] = useState<string | null>("10");
   return (
     <div>
       <Container className="MainContainer">
@@ -144,9 +145,11 @@ const AdCardList = (props: AdCardData) => {
           <Row>
             {props.isWatchingAdSection ? (
               <div>
-                <Row style={{textAlign:"right", paddingRight:"1.3rem"}}>
-                <Col>
-                <span style={{fontSize:"11px"}}>Antal annonser per sida</span>
+                <Row style={{ textAlign: "right", paddingRight: "1.3rem" }}>
+                  <Col>
+                    <span style={{ fontSize: "11px" }}>
+                      Antal annonser per sida
+                    </span>
                     <DropdownButton
                       size="sm"
                       id="dropdown-basic-button"
@@ -200,17 +203,49 @@ const AdCardList = (props: AdCardData) => {
                     <Button variant="primary" size="sm">
                       {props.pageNumber}
                     </Button>{" "}
-                    <Button variant="secondary" size="sm" onClick={(e) => props.recieveDataFromAdCardListChild(props.pageNumber + 1)}>
+                    <Button
+                      variant="secondary"
+                      size="sm"
+                      onClick={(e) =>
+                        props.recieveDataFromAdCardListChild(
+                          props.pageNumber + 1
+                        )
+                      }
+                    >
                       {props.pageNumber + 1}
                     </Button>{" "}
-                    <Button variant="secondary" size="sm" onClick={(e) => props.recieveDataFromAdCardListChild(props.pageNumber + 2)}>
+                    <Button
+                      variant="secondary"
+                      size="sm"
+                      onClick={(e) =>
+                        props.recieveDataFromAdCardListChild(
+                          props.pageNumber + 2
+                        )
+                      }
+                    >
                       {props.pageNumber + 2}
                     </Button>{" "}
-                    <Button variant="secondary" size="sm" onClick={(e) => props.recieveDataFromAdCardListChild(props.pageNumber + 3)}>
+                    <Button
+                      variant="secondary"
+                      size="sm"
+                      onClick={(e) =>
+                        props.recieveDataFromAdCardListChild(
+                          props.pageNumber + 3
+                        )
+                      }
+                    >
                       {props.pageNumber + 3}
                     </Button>{" "}
                     {props.pageNumber === 1 ? (
-                      <Button variant="secondary" size="sm" onClick={(e) => props.recieveDataFromAdCardListChild(props.pageNumber + 4)}>
+                      <Button
+                        variant="secondary"
+                        size="sm"
+                        onClick={(e) =>
+                          props.recieveDataFromAdCardListChild(
+                            props.pageNumber + 4
+                          )
+                        }
+                      >
                         {props.pageNumber + 4}
                       </Button>
                     ) : null}{" "}
@@ -231,7 +266,10 @@ const AdCardList = (props: AdCardData) => {
                 </Row>
               </div>
             ) : (
-              <Statistics searchBarText={props.searchBarText} />
+              <Statistics
+                searchTerm={props.searchTerm}
+                searchCount={props.searchCount}
+              />
             )}
           </Row>
         </Row>

--- a/src/components/common/AdCardList.tsx
+++ b/src/components/common/AdCardList.tsx
@@ -19,7 +19,7 @@ interface AdCardData {
 }
 
 const AdCardList = (props: AdCardData) => {
-  const [pageSize, setPageSize] = useState(5);
+  const [pageSize, setPageSize] = useState("5");
   return (
     <div>
       <Container className="MainContainer">
@@ -139,7 +139,7 @@ const AdCardList = (props: AdCardData) => {
                 <Accordion flush>
                   {props.apiData === null
                     ? null
-                    : props.apiData.map((job: any, index: number) =>
+                    : props.apiData.map((job: any, index: string) =>
                       index >= pageSize ? null : <JobCard savedAdCounter={props.savedAdCounter} key={job.id} job={job} />
                       )}
                 </Accordion>

--- a/src/components/common/AdCardList.tsx
+++ b/src/components/common/AdCardList.tsx
@@ -1,6 +1,14 @@
 import "./css/AdCardList.css";
 import React from "react";
-import { Row, Col, Container, Button, Accordion, Dropdown, DropdownButton } from "react-bootstrap";
+import {
+  Row,
+  Col,
+  Container,
+  Button,
+  Accordion,
+  Dropdown,
+  DropdownButton,
+} from "react-bootstrap";
 import JobCard from "./JobCard";
 import Statistics from "./Statistics";
 import { useState } from "react";
@@ -19,7 +27,7 @@ interface AdCardData {
 }
 
 const AdCardList = (props: AdCardData) => {
-  const [pageSize, setPageSize] = useState("5");
+  const [pageSize, setPageSize] = useState<string | null>("5");
   return (
     <div>
       <Container className="MainContainer">
@@ -140,7 +148,13 @@ const AdCardList = (props: AdCardData) => {
                   {props.apiData === null
                     ? null
                     : props.apiData.map((job: any, index: string) =>
-                      index >= pageSize ? null : <JobCard savedAdCounter={props.savedAdCounter} key={job.id} job={job} />
+                        pageSize !== null && index >= pageSize ? null : (
+                          <JobCard
+                            savedAdCounter={props.savedAdCounter}
+                            key={job.id}
+                            job={job}
+                          />
+                        )
                       )}
                 </Accordion>
                 <Row style={{ textAlign: "center", paddingTop: "1rem" }}>
@@ -179,10 +193,11 @@ const AdCardList = (props: AdCardData) => {
                     <Button variant="secondary" size="sm">
                       {props.pageNumber + 3}
                     </Button>{" "}
-                    {props.pageNumber === 1 ?                     <Button variant="secondary" size="sm">
-                      {props.pageNumber + 4}
-                    </Button> : null }
-                    {" "}
+                    {props.pageNumber === 1 ? (
+                      <Button variant="secondary" size="sm">
+                        {props.pageNumber + 4}
+                      </Button>
+                    ) : null}{" "}
                     <Button
                       variant="secondary"
                       size="sm"
@@ -198,16 +213,22 @@ const AdCardList = (props: AdCardData) => {
                     </Button>{" "}
                   </Col>
                   <Col sm={1}>
-                    <DropdownButton  size="sm" id="dropdown-basic-button" variant="secondary" title={pageSize} onSelect={(e) => setPageSize(e)}>
+                    <DropdownButton
+                      size="sm"
+                      id="dropdown-basic-button"
+                      variant="secondary"
+                      title={pageSize}
+                      onSelect={(e) => setPageSize(e)}
+                    >
                       <Dropdown.Item eventKey="5">5</Dropdown.Item>
                       <Dropdown.Item eventKey="10">10</Dropdown.Item>
                       <Dropdown.Item eventKey="20">20</Dropdown.Item>
                     </DropdownButton>
-                </Col>
+                  </Col>
                 </Row>
               </div>
             ) : (
-              <Statistics searchBarText={props.searchBarText}/>
+              <Statistics searchBarText={props.searchBarText} />
             )}
           </Row>
         </Row>

--- a/src/components/common/JobCard.tsx
+++ b/src/components/common/JobCard.tsx
@@ -1,10 +1,11 @@
 import "./css/JobCard.css";
-import { Col, Row, Accordion } from "react-bootstrap";
+import { Col, Row, Accordion, Button } from "react-bootstrap";
 import { Star, StarFill } from "react-bootstrap-icons";
 import { useState, useEffect } from "react";
 
 const JobCard = (props: any) => {
   const publicationString = props.job.publication_date.replace(/T|Z/g, " ");
+  const deadlineString = props.job.deadline.replace(/T|Z/g, " ");
   const [isSaved, setSaved] = useState(false);
 
   useEffect(() => {
@@ -34,6 +35,11 @@ const JobCard = (props: any) => {
 
     localStorage.setItem("allEntries", JSON.stringify(existingEntries));
   }
+
+  const openInNewTab = (url:string) => {
+    const newWindow = window.open(url, "_blank", "noopener,noreferrer");
+    if (newWindow) newWindow.opener = null;
+  };
 
   const toggleSaved = (e: any, id: string) => {
     e.stopPropagation();
@@ -86,7 +92,47 @@ const JobCard = (props: any) => {
         </span>
       </Accordion.Header>
       <Accordion.Body>
-        <div className="CardDescription">{props.job.description.text}</div>
+        <Row style={{ height: "5rem" }}>
+          <Col sm={8}>
+            <p style={{ fontWeight: "600", fontSize: "1rem" }}>
+              {props.job.occupation.label}
+              <br />
+              <span style={{ fontWeight: "400", fontSize: ".75rem" }}>
+                {props.job.working_hours_type.label} {props.job.duration.label}
+                <br />
+                {props.job.salary_type.label}
+                {props.job.employer.url !== null ? (
+                  <span>
+                    <br />
+                    Webadress:{" "}
+                    <a target="_blank" href={props.job.employer.url}>
+                      {props.job.employer.url}
+                    </a>
+                  </span>
+                ) : null}
+              </span>
+            </p>
+          </Col>
+          <Col sm={4} style={{ textAlign: "right", paddingTop: "1.5rem" }}>
+            <Button
+              size="lg"
+              variant="outline-dark"
+              disabled={props.job.removed}
+              onClick={() =>
+                openInNewTab(
+                  !props.job.application_details.via_af && props.job.application_details.url !== null
+                    ? props.job.application_details.url
+                    : props.job.webpage_url
+                )
+              }
+            >
+              Ansök nu!
+            </Button>{" "}
+          </Col>
+        </Row>
+        <Row style={{ marginTop: "2rem", fontSize: ".75rem" }}>
+          <Col>{props.job.description.text}</Col>
+        </Row>
       </Accordion.Body>
     </Accordion.Item>
   );

--- a/src/components/common/JobCard.tsx
+++ b/src/components/common/JobCard.tsx
@@ -5,7 +5,6 @@ import { useState, useEffect } from "react";
 
 const JobCard = (props: any) => {
   const publicationString = props.job.publication_date.replace(/T|Z/g, " ");
-  const deadlineString = props.job.deadline.replace(/T|Z/g, " ");
   const [isSaved, setSaved] = useState(false);
 
   useEffect(() => {
@@ -16,6 +15,7 @@ const JobCard = (props: any) => {
         setSaved(true);
       } else setSaved(false);
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.savedAdCounter, isSaved]);
 
   function toggleLocalStorage(entry: string) {
@@ -105,7 +105,7 @@ const JobCard = (props: any) => {
                   <span>
                     <br />
                     Webadress:{" "}
-                    <a target="_blank" href={props.job.employer.url}>
+                    <a target="_blank" rel="noreferrer" href={props.job.employer.url}>
                       {props.job.employer.url}
                     </a>
                   </span>

--- a/src/components/common/JobCard.tsx
+++ b/src/components/common/JobCard.tsx
@@ -10,33 +10,34 @@ const JobCard = (props: any) => {
   useEffect(() => {
     // @ts-ignore
     var existingEntries = JSON.parse(localStorage.getItem("allEntries"));
-    if(existingEntries !== null){
-      if(existingEntries.includes(props.job.id)) setSaved(true);
+    if (existingEntries !== null) {
+      if (existingEntries.includes(props.job.id)) {
+        setSaved(true);
+      } else setSaved(false);
     }
-  }, []);
+  }, [props.savedAdCounter, isSaved]);
 
   function toggleLocalStorage(entry: string) {
     // Parse any JSON previously stored in allEntries
     // @ts-ignore
     var existingEntries = JSON.parse(localStorage.getItem("allEntries"));
-    if(existingEntries == null) existingEntries = [];
+    if (existingEntries == null) existingEntries = [];
 
-    const index = existingEntries.indexOf(entry)
-    if(existingEntries.includes(entry)){
-      existingEntries.splice(index, 1)
-    }
-    else{
+    const index = existingEntries.indexOf(entry);
+    if (existingEntries.includes(entry)) {
+      existingEntries.splice(index, 1);
+    } else {
       localStorage.setItem("entry", JSON.stringify(entry));
       // Save allEntries back to local storage
       existingEntries.push(entry);
     }
 
     localStorage.setItem("allEntries", JSON.stringify(existingEntries));
-  };
+  }
 
   const toggleSaved = (e: any, id: string) => {
     e.stopPropagation();
-    toggleLocalStorage(id)
+    toggleLocalStorage(id);
     setSaved((prevSaved) => !prevSaved);
     props.savedAdCounter();
   };
@@ -55,9 +56,7 @@ const JobCard = (props: any) => {
                 <div className="CardTitle">{props.job.headline}</div>
               </Row>
               <Row>
-                <div className="CardDescription">
-                  {props.job.employer.name}
-                </div>
+                <div className="CardDescription">{props.job.employer.name}</div>
               </Row>
               <Row>
                 <Col>
@@ -65,8 +64,7 @@ const JobCard = (props: any) => {
                   <Row>
                     {" "}
                     <div className="CardPublicationDate">
-                      Publicerad: {" "}
-                      {publicationString}
+                      Publicerad: {publicationString}
                     </div>
                   </Row>
                 </Col>

--- a/src/components/common/JobCard.tsx
+++ b/src/components/common/JobCard.tsx
@@ -5,7 +5,6 @@ import { useState, useEffect } from "react";
 
 const JobCard = (props: any) => {
   const publicationString = props.job.publication_date.replace(/T|Z/g, " ");
-  const deadlineString = props.job.deadline.replace(/T|Z/g, " ");
   const [isSaved, setSaved] = useState(false);
 
   useEffect(() => {

--- a/src/components/common/JobCardDefaultOpen.tsx
+++ b/src/components/common/JobCardDefaultOpen.tsx
@@ -1,0 +1,146 @@
+import "./css/JobCard.css";
+import { Col, Row, Accordion, Button } from "react-bootstrap";
+import { Star, StarFill } from "react-bootstrap-icons";
+import { useState, useEffect } from "react";
+
+const JobCard = (props: any) => {
+  const publicationString = props.job.publication_date.replace(/T|Z/g, " ");
+  const [isSaved, setSaved] = useState(false);
+
+  useEffect(() => {
+    // @ts-ignore
+    var existingEntries = JSON.parse(localStorage.getItem("allEntries"));
+    if (existingEntries !== null) {
+      if (existingEntries.includes(props.job.id)) {
+        setSaved(true);
+      } else setSaved(false);
+    }
+  }, [props.savedAdCounter, isSaved]);
+
+  function toggleLocalStorage(entry: string) {
+    // Parse any JSON previously stored in allEntries
+    // @ts-ignore
+    var existingEntries = JSON.parse(localStorage.getItem("allEntries"));
+    if (existingEntries == null) existingEntries = [];
+
+    const index = existingEntries.indexOf(entry);
+    if (existingEntries.includes(entry)) {
+      existingEntries.splice(index, 1);
+    } else {
+      localStorage.setItem("entry", JSON.stringify(entry));
+      // Save allEntries back to local storage
+      existingEntries.push(entry);
+    }
+
+    localStorage.setItem("allEntries", JSON.stringify(existingEntries));
+  }
+
+  const openInNewTab = (url: string) => {
+    const newWindow = window.open(url, "_blank", "noopener,noreferrer");
+    if (newWindow) newWindow.opener = null;
+  };
+
+  const toggleSaved = (e: any, id: string) => {
+    e.stopPropagation();
+    toggleLocalStorage(id);
+    setSaved((prevSaved) => !prevSaved);
+    props.savedAdCounter();
+  };
+  return (
+    <Accordion defaultActiveKey={props.job.id} flush>
+      <Accordion.Item eventKey={props.job.id}>
+        <Accordion.Header>
+          <div className="Card">
+            <Row>
+              <Col sm={3}>
+                <div className="CardLogo">
+                  <img alt="" src={props.job.logo_url}></img>
+                </div>
+              </Col>
+              <Col sm={9}>
+                <Row>
+                  <div className="CardTitle">{props.job.headline}</div>
+                </Row>
+                <Row>
+                  <div className="CardDescription">
+                    {props.job.employer.name}
+                  </div>
+                </Row>
+                <Row>
+                  <Col>
+                    {" "}
+                    <Row>
+                      {" "}
+                      <div className="CardPublicationDate">
+                        Publicerad: {publicationString}
+                      </div>
+                    </Row>
+                  </Col>
+                </Row>
+              </Col>
+            </Row>
+          </div>
+          <span
+            className="SaveIcon"
+            style={{ float: "right" }}
+            onClick={(e) => toggleSaved(e, props.job.id)}
+          >
+            {" "}
+            {!isSaved ? (
+              <Star style={{ fontSize: "24px", margin: "10px" }} />
+            ) : (
+              <StarFill style={{ fontSize: "24px", margin: "10px" }} />
+            )}
+          </span>
+        </Accordion.Header>
+        <Accordion.Body>
+          <Row style={{ height: "5rem" }}>
+            <Col sm={8}>
+              <p style={{ fontWeight: "600", fontSize: "1rem" }}>
+                {props.job.occupation.label}
+                <br />
+                <span style={{ fontWeight: "400", fontSize: ".75rem" }}>
+                  {props.job.working_hours_type.label}{" "}
+                  {props.job.duration.label}
+                  <br />
+                  {props.job.salary_type.label}
+                  {props.job.employer.url !== null ? (
+                    <span>
+                      <br />
+                      Webadress:{" "}
+                      <a target="_blank" href={props.job.employer.url}>
+                        {props.job.employer.url}
+                      </a>
+                    </span>
+                  ) : null}
+                </span>
+              </p>
+            </Col>
+            <Col sm={4} style={{ textAlign: "right", paddingTop: "1.5rem" }}>
+              <Button
+                size="lg"
+                variant="outline-dark"
+                disabled={props.job.removed}
+                onClick={() =>
+                  openInNewTab(
+                    !props.job.application_details.via_af &&
+                      props.job.application_details.url !== null
+                      ? props.job.application_details.url
+                      : props.job.webpage_url
+                  )
+                }
+              >
+                Ansök nu!
+              </Button>{" "}
+            </Col>
+          </Row>
+          <Row style={{ marginTop: "2rem", fontSize: ".75rem" }}>
+            <Col>{props.job.description.text}</Col>
+          </Row>
+        </Accordion.Body>
+      </Accordion.Item>
+    </Accordion>
+  );
+};
+
+export default JobCard;

--- a/src/components/common/JobCardDefaultOpen.tsx
+++ b/src/components/common/JobCardDefaultOpen.tsx
@@ -15,6 +15,7 @@ const JobCard = (props: any) => {
         setSaved(true);
       } else setSaved(false);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.savedAdCounter, isSaved]);
 
   function toggleLocalStorage(entry: string) {
@@ -108,7 +109,7 @@ const JobCard = (props: any) => {
                     <span>
                       <br />
                       Webadress:{" "}
-                      <a target="_blank" href={props.job.employer.url}>
+                      <a target="_blank" rel="noreferrer" href={props.job.employer.url}>
                         {props.job.employer.url}
                       </a>
                     </span>

--- a/src/components/common/SavedAds.tsx
+++ b/src/components/common/SavedAds.tsx
@@ -77,9 +77,9 @@ const SavedAds = (props: any) => {
           >
             <Col sm={10}>
               <div>
-                {job.headline.length < 40
+                {job.headline.length < 35
                   ? job.headline
-                  : job.headline.substring(0, 40) + "..."}
+                  : job.headline.substring(0, 35) + "..."}
               </div>
             </Col>
             <Col

--- a/src/components/common/SavedAds.tsx
+++ b/src/components/common/SavedAds.tsx
@@ -55,8 +55,14 @@ const SavedAds = (props: any) => {
     }
   };
 
-  useEffect(() => getSavedAds(), [props.savedAdCounter]);
-  useEffect(() => getAdsData(), [queryString]);
+  useEffect(() => {
+    getSavedAds();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [props.savedAdCounter]);
+  useEffect(() => {
+    getAdsData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [queryString]);
   return (
     <>
       {savedAdsData.length === 0 ? (
@@ -75,7 +81,13 @@ const SavedAds = (props: any) => {
               cursor: "pointer",
             }}
           >
-            <Col sm={10} onClick={() => (props.callbackChangeisWatchingSingleAdTrue(), props.callbackChangeSingleAdData(savedAdsData, job.id))}>
+            <Col
+              sm={10}
+              onClick={() => (
+                props.callbackChangeisWatchingSingleAdTrue(),
+                props.callbackChangeSingleAdData(savedAdsData, job.id)
+              )}
+            >
               <div>
                 {job.headline.length < 35
                   ? job.headline

--- a/src/components/common/SavedAds.tsx
+++ b/src/components/common/SavedAds.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect } from "react";
-import { Row, Col, Container } from "react-bootstrap";
 
 const SavedAds = (props: any) => {
   const [queryString, setQueryString] = useState("");

--- a/src/components/common/SavedAds.tsx
+++ b/src/components/common/SavedAds.tsx
@@ -1,8 +1,34 @@
 import { useState, useEffect } from "react";
+import { Row, Col } from "react-bootstrap";
+import { TrashFill, Star } from "react-bootstrap-icons";
 
 const SavedAds = (props: any) => {
   const [queryString, setQueryString] = useState("");
   const [savedAdsData, setSavedAdsData] = useState([]);
+
+  function toggleLocalStorage(entry: string) {
+    // Parse any JSON previously stored in allEntries
+    // @ts-ignore
+    var existingEntries = JSON.parse(localStorage.getItem("allEntries"));
+    if (existingEntries == null) existingEntries = [];
+
+    const index = existingEntries.indexOf(entry);
+    if (existingEntries.includes(entry)) {
+      existingEntries.splice(index, 1);
+    } else {
+      localStorage.setItem("entry", JSON.stringify(entry));
+      // Save allEntries back to local storage
+      existingEntries.push(entry);
+    }
+
+    localStorage.setItem("allEntries", JSON.stringify(existingEntries));
+  }
+
+  const deleteSavedAd = (e: any, id: string) => {
+    e.stopPropagation();
+    toggleLocalStorage(id);
+    props.savedAdCounter();
+  };
 
   const getSavedAds = () => {
     // Get ad ids from local storage
@@ -10,7 +36,10 @@ const SavedAds = (props: any) => {
     var existingEntries = JSON.parse(localStorage.getItem("allEntries"));
     if (existingEntries !== null) {
       // Create query string
-      var ids = existingEntries.map((id: string) => id + "&ids=").join("").slice(0, - 5);
+      var ids = existingEntries
+        .map((id: string) => id + "&ids=")
+        .join("")
+        .slice(0, -5);
 
       setQueryString(ids);
     }
@@ -27,18 +56,43 @@ const SavedAds = (props: any) => {
   };
 
   useEffect(() => getSavedAds(), [props.savedAdCounter]);
-
   useEffect(() => getAdsData(), [queryString]);
   return (
-    <div>
-      {savedAdsData === undefined || null
-        ? null
-        : savedAdsData.map((job: any) => (
-            <div key={job.id} onClick={() => console.log(job.headline)}>
-              {job.headline}
-            </div>
-          ))}
-    </div>
+    <>
+      {savedAdsData.length === 0 ? (
+        <p style={{ textAlign: "center", fontSize: "11px" }}>
+          Hittade inga sparade annonser
+          <br />
+          Använd <Star /> för att markera dina favoritannonser
+        </p>
+      ) : savedAdsData === undefined || null ? null : (
+        savedAdsData.map((job: any) => (
+          <Row
+            key={job.id}
+            style={{
+              paddingBottom: "0.2rem",
+              fontSize: "11px",
+              cursor: "pointer",
+            }}
+          >
+            <Col sm={10}>
+              <div>
+                {job.headline.length < 40
+                  ? job.headline
+                  : job.headline.substring(0, 40) + "..."}
+              </div>
+            </Col>
+            <Col
+              sm={2}
+              style={{ textAlign: "right" }}
+              onClick={(e) => deleteSavedAd(e, job.id)}
+            >
+              <TrashFill />
+            </Col>
+          </Row>
+        ))
+      )}
+    </>
   );
 };
 export default SavedAds;

--- a/src/components/common/SavedAds.tsx
+++ b/src/components/common/SavedAds.tsx
@@ -75,7 +75,7 @@ const SavedAds = (props: any) => {
               cursor: "pointer",
             }}
           >
-            <Col sm={10}>
+            <Col sm={10} onClick={() => (props.callbackChangeisWatchingSingleAdTrue(), props.callbackChangeSingleAdData(savedAdsData, job.id))}>
               <div>
                 {job.headline.length < 35
                   ? job.headline

--- a/src/components/common/SingleAdList.tsx
+++ b/src/components/common/SingleAdList.tsx
@@ -1,0 +1,55 @@
+import "./css/AdCardList.css";
+import React from "react";
+import { Row, Container } from "react-bootstrap";
+import JobCardDefaultOpen from "./JobCardDefaultOpen";
+
+interface Props {
+  callbackChangeisWatchingSingleAdFalse: any;
+  singleAdData: any;
+  savedAdCounter: any;
+}
+
+const SingleAdList = (props: Props) => {
+  return (
+    <div>
+      <Container className="MainContainer">
+        <Row>
+          <div>
+            <span
+              style={{
+                color: "gray",
+                cursor: "pointer",
+                fontSize: "12px",
+                borderBottom: "2px solid rgba(54, 174, 243)",
+                display: "inline-block",
+                height: "2rem",
+              }}
+              onClick={() => props.callbackChangeisWatchingSingleAdFalse()}
+            >
+              Tillbaka
+            </span>
+            <span
+              style={{
+                width: "96%",
+                color: "gray",
+                borderTop: "1px solid #dfdfdf",
+                display: "inline-block",
+                height: "2rem",
+              }}
+            ></span>
+          </div>
+            {props.singleAdData === null
+              ? null
+              : props.singleAdData.map((job: any) => (
+                  <JobCardDefaultOpen
+                    savedAdCounter={props.savedAdCounter}
+                    key={job.id}
+                    job={job}
+                  />
+                ))}
+        </Row>
+      </Container>
+    </div>
+  );
+};
+export default SingleAdList;

--- a/src/components/common/Statistics.tsx
+++ b/src/components/common/Statistics.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect } from "react";
 import { Row, Col, Container } from "react-bootstrap";
-import { StringMappingType } from "typescript";
 import VerticalBar from "./StatisticsVerticalBar";
 
 interface Props {

--- a/src/components/common/Statistics.tsx
+++ b/src/components/common/Statistics.tsx
@@ -61,59 +61,11 @@ const Statistics = (props: Props) => {
                 textAlign: "left",
               }}
             >
-              Populära arbetsgivare
-            </p>
-            <Col sm={4}>
-              {employerStatisticData.slice(0, 5).map((employeer: any) => (
-                <Row key={employeer._id} onClick={(e) => console.log("hello")}>
-                  <p style={{ fontSize: "12px", textAlign: "left" }}>
-                    {employeer._id}{" "}
-                    <span style={{ fontWeight: "600" }}>
-                      ({employeer.count})
-                    </span>
-                  </p>
-                </Row>
-              ))}
-            </Col>
-            <Col sm={4}>
-              {employerStatisticData.slice(5, 10).map((employeer: any) => (
-                <Row key={employeer._id}>
-                  <p style={{ fontSize: "12px", textAlign: "left" }}>
-                    {employeer._id}{" "}
-                    <span style={{ fontWeight: "600" }}>
-                      ({employeer.count})
-                    </span>
-                  </p>
-                </Row>
-              ))}
-            </Col>
-            <Col sm={4}>
-              {employerStatisticData.slice(10, 15).map((employeer: any) => (
-                <Row key={employeer._id}>
-                  <p style={{ fontSize: "12px", textAlign: "left" }}>
-                    {employeer._id}{" "}
-                    <span style={{ fontWeight: "600" }}>
-                      ({employeer.count})
-                    </span>
-                  </p>
-                </Row>
-              ))}
-            </Col>
-          </Row>
-          <Row style={{ textAlign: "center", paddingTop: "2rem" }}>
-            <p
-              style={{
-                color: "darkslategray",
-                fontSize: "16px",
-                fontWeight: "600",
-                textAlign: "left",
-              }}
-            >
               Populära Kategorier
             </p>
             <Col sm={4}>
               {categoryStatisticData.slice(0, 5).map((category: any) => (
-                <Row key={category._id} onClick={(e) => console.log("hello")}>
+                <Row key={category._id}>
                   <p style={{ fontSize: "12px", textAlign: "left" }}>
                     {category._id}{" "}
                     <span style={{ fontWeight: "600" }}>
@@ -142,6 +94,54 @@ const Statistics = (props: Props) => {
                     {category._id}{" "}
                     <span style={{ fontWeight: "600" }}>
                       ({category.count})
+                    </span>
+                  </p>
+                </Row>
+              ))}
+            </Col>
+          </Row>
+          <Row style={{ textAlign: "center", paddingTop: "2rem" }}>
+            <p
+              style={{
+                color: "darkslategray",
+                fontSize: "16px",
+                fontWeight: "600",
+                textAlign: "left",
+              }}
+            >
+              Populära arbetsgivare
+            </p>
+            <Col sm={4}>
+              {employerStatisticData.slice(0, 5).map((employeer: any) => (
+                <Row key={employeer._id}>
+                  <p style={{ fontSize: "12px", textAlign: "left" }}>
+                    {employeer._id}{" "}
+                    <span style={{ fontWeight: "600" }}>
+                      ({employeer.count})
+                    </span>
+                  </p>
+                </Row>
+              ))}
+            </Col>
+            <Col sm={4}>
+              {employerStatisticData.slice(5, 10).map((employeer: any) => (
+                <Row key={employeer._id}>
+                  <p style={{ fontSize: "12px", textAlign: "left" }}>
+                    {employeer._id}{" "}
+                    <span style={{ fontWeight: "600" }}>
+                      ({employeer.count})
+                    </span>
+                  </p>
+                </Row>
+              ))}
+            </Col>
+            <Col sm={4}>
+              {employerStatisticData.slice(10, 15).map((employeer: any) => (
+                <Row key={employeer._id}>
+                  <p style={{ fontSize: "12px", textAlign: "left" }}>
+                    {employeer._id}{" "}
+                    <span style={{ fontWeight: "600" }}>
+                      ({employeer.count})
                     </span>
                   </p>
                 </Row>

--- a/src/components/common/Statistics.tsx
+++ b/src/components/common/Statistics.tsx
@@ -1,14 +1,17 @@
 import { useState, useEffect } from "react";
 import { Row, Col, Container } from "react-bootstrap";
+import { StringMappingType } from "typescript";
 import VerticalBar from "./StatisticsVerticalBar";
 
 interface Props {
-  searchBarText: string;
+  searchTerm: string;
+  searchCount: number;
 }
 
 const Statistics = (props: Props) => {
   const [employerStatisticData, setEmployerStatisticData] = useState([]);
   const [categoryStatisticData, setCategoryStatisticData] = useState([]);
+  const [searchTermStatistics, setSearchTermStatistics] = useState([]);
 
   useEffect(() => {
     const fetchEmployerStatistics = async () => {
@@ -30,11 +33,26 @@ const Statistics = (props: Props) => {
     fetchCategoryStatistics();
   }, []);
 
+  useEffect(() => {
+    setSearchTermStatistics([]);
+    const fetchSerchTermStatistics = async () => {
+      const API =
+        "http://82.102.1.109/api/joblistings/statistics/" + props.searchTerm;
+      await fetch(API)
+        .then((response) => response.json())
+        .then((data) => setSearchTermStatistics(data.date))
+        .catch((err) => console.error(err));
+    };
+    if (props.searchTerm !== "") fetchSerchTermStatistics();
+  }, [props.searchTerm]);
+
   return (
     <Container>
       <Row>
         <Col sm={12}>
-          {/* <VerticalBar searchString={props.searchBarText} /> */}
+          {props.searchCount > 0 ? (
+            <VerticalBar searchTerm={props.searchTerm} searchTermStatistics={searchTermStatistics} />
+          ) : null}
           <Row style={{ textAlign: "center", paddingTop: "2rem" }}>
             <p
               style={{
@@ -50,7 +68,10 @@ const Statistics = (props: Props) => {
               {employerStatisticData.slice(0, 5).map((employeer: any) => (
                 <Row key={employeer._id} onClick={(e) => console.log("hello")}>
                   <p style={{ fontSize: "12px", textAlign: "left" }}>
-                  {employeer._id} <span style={{fontWeight:"600"}}>({employeer.count})</span>
+                    {employeer._id}{" "}
+                    <span style={{ fontWeight: "600" }}>
+                      ({employeer.count})
+                    </span>
                   </p>
                 </Row>
               ))}
@@ -59,7 +80,10 @@ const Statistics = (props: Props) => {
               {employerStatisticData.slice(5, 10).map((employeer: any) => (
                 <Row key={employeer._id}>
                   <p style={{ fontSize: "12px", textAlign: "left" }}>
-                    {employeer._id} <span style={{fontWeight:"600"}}>({employeer.count})</span>
+                    {employeer._id}{" "}
+                    <span style={{ fontWeight: "600" }}>
+                      ({employeer.count})
+                    </span>
                   </p>
                 </Row>
               ))}
@@ -68,7 +92,10 @@ const Statistics = (props: Props) => {
               {employerStatisticData.slice(10, 15).map((employeer: any) => (
                 <Row key={employeer._id}>
                   <p style={{ fontSize: "12px", textAlign: "left" }}>
-                  {employeer._id} <span style={{fontWeight:"600"}}>({employeer.count})</span>
+                    {employeer._id}{" "}
+                    <span style={{ fontWeight: "600" }}>
+                      ({employeer.count})
+                    </span>
                   </p>
                 </Row>
               ))}
@@ -89,7 +116,10 @@ const Statistics = (props: Props) => {
               {categoryStatisticData.slice(0, 5).map((category: any) => (
                 <Row key={category._id} onClick={(e) => console.log("hello")}>
                   <p style={{ fontSize: "12px", textAlign: "left" }}>
-                  {category._id} <span style={{fontWeight:"600"}}>({category.count})</span>
+                    {category._id}{" "}
+                    <span style={{ fontWeight: "600" }}>
+                      ({category.count})
+                    </span>
                   </p>
                 </Row>
               ))}
@@ -98,7 +128,10 @@ const Statistics = (props: Props) => {
               {categoryStatisticData.slice(5, 10).map((category: any) => (
                 <Row key={category._id}>
                   <p style={{ fontSize: "12px", textAlign: "left" }}>
-                    {category._id} <span style={{fontWeight:"600"}}>({category.count})</span>
+                    {category._id}{" "}
+                    <span style={{ fontWeight: "600" }}>
+                      ({category.count})
+                    </span>
                   </p>
                 </Row>
               ))}
@@ -107,7 +140,10 @@ const Statistics = (props: Props) => {
               {categoryStatisticData.slice(10, 15).map((category: any) => (
                 <Row key={category._id}>
                   <p style={{ fontSize: "12px", textAlign: "left" }}>
-                  {category._id} <span style={{fontWeight:"600"}}>({category.count})</span>
+                    {category._id}{" "}
+                    <span style={{ fontWeight: "600" }}>
+                      ({category.count})
+                    </span>
                   </p>
                 </Row>
               ))}

--- a/src/components/common/StatisticsVerticalBar.tsx
+++ b/src/components/common/StatisticsVerticalBar.tsx
@@ -1,4 +1,6 @@
-import { Bar } from 'react-chartjs-2';
+import { useEffect, useState } from "react";
+import { Bar } from "react-chartjs-2";
+import { Spinner } from "react-bootstrap";
 import {
   Chart as ChartJS,
   CategoryScale,
@@ -7,10 +9,11 @@ import {
   Title,
   Tooltip,
   Legend,
-} from 'chart.js';
+} from "chart.js";
 
 interface Props {
-  searchString: string;
+  searchTerm: string;
+  searchTermStatistics: any;
 }
 
 const StatisticsVerticalBar = (props: Props) => {
@@ -22,16 +25,14 @@ const StatisticsVerticalBar = (props: Props) => {
     Tooltip,
     Legend
   );
-  
-  function getRandomInt(max:number) {
-    return Math.floor(Math.random() * max);
-  }
-  
+
+  const statisticData: number[] = [];
+
   const options = {
     responsive: true,
     plugins: {
       legend: {
-        position: 'top' as const,
+        position: "top" as const,
       },
       title: {
         display: false,
@@ -39,22 +40,121 @@ const StatisticsVerticalBar = (props: Props) => {
       },
     },
   };
-  
-  const labels = ['Januari', 'Februari', 'Mars', 'April', 'Maj', 'Juni', 'Juli', 'Augusti', 'September', 'Oktober', 'November', 'December'];
-  
+
+  const labels = [
+    "Januari",
+    "Februari",
+    "Mars",
+    "April",
+    "Maj",
+    "Juni",
+    "Juli",
+    "Augusti",
+    "September",
+    "Oktober",
+    "November",
+    "December",
+  ];
+
+  let jan = 0;
+  let feb = 0;
+  let march = 0;
+  let april = 0;
+  let may = 0;
+  let june = 0;
+  let july = 0;
+  let august = 0;
+  let september = 0;
+  let october = 0;
+  let november = 0;
+  let december = 0;
+
   const data = {
     labels,
     datasets: [
       {
-        label: "Annonser relaterat till " + props.searchString,
-        data: labels.map(() => getRandomInt(1000)),
-        backgroundColor: 'rgba(39, 38, 53, .8)',
-      }
+        label: "Annonser relaterat till " + props.searchTerm,
+        data: statisticData,
+        backgroundColor: "rgba(39, 38, 53, .8)",
+      },
     ],
   };
-  return <Bar options={options} data={data} />;
+
+  return (
+    <div style={{ textAlign: "center" }}>
+      {props.searchTermStatistics.length === 0 ? (
+        <div>
+          <p>Hämtar statistik</p>
+          <Spinner animation="border" />
+        </div>
+      ) : (
+        <div>
+          {props.searchTermStatistics === null ||
+          props.searchTermStatistics === undefined ? null : (
+            <div>
+              {props.searchTermStatistics.map((stats: any) => {
+                // Convert to Date Object
+                let date = new Date(stats.date);
+
+                // Based on month, we want to append to selected index in statisticData
+                switch (date.getMonth()) {
+                  case 0: {
+                    jan += stats.count;
+                    break;
+                  }
+                  case 1: {
+                    feb += stats.count;
+                    break;
+                  }
+                  case 2: {
+                    march += stats.count;
+                    break;
+                  }
+                  case 3: {
+                    april += stats.count;
+                    break;
+                  }
+                  case 4: {
+                    may += stats.count;
+                    break;
+                  }
+                  case 5: {
+                    june += stats.count;
+                    break;
+                  }
+                  case 6: {
+                    july += stats.count;
+                    break;
+                  }
+                  default: {
+                    break;
+                  }
+                }
+              })}
+              <p style={{ fontSize: "0" }}>
+                {/* For some reason, JSX tries to write out the lenght of the array here without making the text.. invisiable... tell me whyyyyyy */}
+                {statisticData.push(
+                  jan,
+                  feb,
+                  march,
+                  april,
+                  may,
+                  june,
+                  july,
+                  august,
+                  september,
+                  october,
+                  november,
+                  december
+                )}
+              </p>
+              <Bar options={options} data={data} />
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
 };
 
 export default StatisticsVerticalBar;
-
-

--- a/src/components/common/StatisticsVerticalBar.tsx
+++ b/src/components/common/StatisticsVerticalBar.tsx
@@ -129,6 +129,7 @@ const StatisticsVerticalBar = (props: Props) => {
                     break;
                   }
                 }
+                return <></>
               })}
               <p style={{ fontSize: "0" }}>
                 {/* For some reason, JSX tries to write out the lenght of the array here without making the text.. invisiable... tell me whyyyyyy */}

--- a/src/components/common/StatisticsVerticalBar.tsx
+++ b/src/components/common/StatisticsVerticalBar.tsx
@@ -72,7 +72,7 @@ const StatisticsVerticalBar = (props: Props) => {
     labels,
     datasets: [
       {
-        label: "Annonser relaterat till " + props.searchTerm,
+        label: "Annonser relaterat till " + props.searchTerm + " 2021",
         data: statisticData,
         backgroundColor: "rgba(39, 38, 53, .8)",
       },

--- a/src/components/common/StatisticsVerticalBar.tsx
+++ b/src/components/common/StatisticsVerticalBar.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from "react";
 import { Bar } from "react-chartjs-2";
 import { Spinner } from "react-bootstrap";
 import {

--- a/src/components/public/Home.tsx
+++ b/src/components/public/Home.tsx
@@ -2,6 +2,7 @@ import "./css/Home.css";
 import { useState, useEffect } from "react";
 import Header from "../common/Header";
 import AdCardList from "../common/AdCardList";
+import SingleAdList from "../common/SingleAdList";
 import { Row, Col, Container } from "react-bootstrap";
 import SavedAds from "../common/SavedAds";
 
@@ -17,6 +18,8 @@ const Home = () => {
   const [prevPageNumber, setPrevPageNumber] = useState(1);
   const [adCounter, setAdCounter] = useState(0);
   const [searchTerm, setSearchTerm] = useState("");
+  const [isWatchingSingleAd, setIsWatchingSingleAd] = useState(false);
+  const [singleAdData, setSingleAdData] = useState({});
 
   // Callback function to receive what page number user is at on AdCardList.tsx
   const recieveDataFromAdCardListChild = (page: number) => {
@@ -39,6 +42,28 @@ const Home = () => {
     setSearchBarText("");
     setCurrentPage(prevPageNumber);
     setSearchCount(0);
+  };
+
+  // Callback function to change isWatchingSingleAd to true from SavedAds.txt
+  const callbackChangeisWatchingSingleAdTrue = () => {
+    setIsWatchingSingleAd(true);
+  };
+
+  // Callback function to change isWatchingSingleAd to false from SingleAdList.txt
+  const callbackChangeisWatchingSingleAdFalse = () => {
+    setIsWatchingSingleAd(false);
+
+  };
+
+  // Callback function to change singleAdId from SavedAds.txt
+  const callbackChangeSingleAdData = (arr: any, id: string) => {
+    var array = [];
+    for (let i = 0; i < arr.length; i++) {
+      if(arr[i].id === id) {
+        array.push(arr[i]);
+        setSingleAdData(array);
+      }
+    }
   };
 
   // Callback function to know when user request a new search for ads in Header.tsx
@@ -106,7 +131,7 @@ const Home = () => {
         <Row>
           <Col sm={3} className="SavedAdsContainer">
             <Container style={{ textAlign: "left" }}>
-            <span
+              <span
                 style={{
                   color: "gray",
                   cursor: "default",
@@ -117,23 +142,37 @@ const Home = () => {
               >
                 Sparade annonser
               </span>
-              <SavedAds savedAdCounter={savedAdCounter} />
+              <SavedAds
+                savedAdCounter={savedAdCounter}
+                callbackChangeisWatchingSingleAdTrue={callbackChangeisWatchingSingleAdTrue}
+                callbackChangeSingleAdData={callbackChangeSingleAdData}
+              />
             </Container>
           </Col>
           <Col sm={9} className="LatestAdsContainer">
-            <AdCardList
-              apiData={latestAdApiData}
-              pageNumber={currentPage}
-              recieveDataFromAdCardListChild={recieveDataFromAdCardListChild}
-              isWatchingAdSection={isWatchingAdSection}
-              changeIsWatchingAdSection={changeIsWatchingAdSection}
-              isSearching={isSearching}
-              changeIsSearching={changeIsSearching}
-              isLoading={isLoading}
-              savedAdCounter={savedAdCounter}
-              searchTerm={searchTerm}
-              searchCount={searchCount}
-            />
+            {!isWatchingSingleAd ? (
+              <AdCardList
+                apiData={latestAdApiData}
+                pageNumber={currentPage}
+                recieveDataFromAdCardListChild={recieveDataFromAdCardListChild}
+                isWatchingAdSection={isWatchingAdSection}
+                changeIsWatchingAdSection={changeIsWatchingAdSection}
+                isSearching={isSearching}
+                changeIsSearching={changeIsSearching}
+                isLoading={isLoading}
+                savedAdCounter={savedAdCounter}
+                searchTerm={searchTerm}
+                searchCount={searchCount}
+              />
+            ) : (
+              <SingleAdList
+                callbackChangeisWatchingSingleAdFalse={
+                  callbackChangeisWatchingSingleAdFalse
+                }
+                singleAdData={singleAdData}
+                savedAdCounter={savedAdCounter}
+              />
+            )}
           </Col>
         </Row>
       </Container>

--- a/src/components/public/Home.tsx
+++ b/src/components/public/Home.tsx
@@ -24,6 +24,7 @@ const Home = () => {
   // Callback function to receive what page number user is at on AdCardList.tsx
   const recieveDataFromAdCardListChild = (page: number) => {
     setCurrentPage(page);
+    window.scrollTo(0,0);
   };
 
   // Callback function to change state of isWatchingAdSection from AdCardList.tsx

--- a/src/components/public/Home.tsx
+++ b/src/components/public/Home.tsx
@@ -17,6 +17,7 @@ const Home = () => {
   const [currentPage, setCurrentPage] = useState(1);
   const [prevPageNumber, setPrevPageNumber] = useState(1);
   const [adCounter, setAdCounter] = useState(0);
+  const [searchTerm, setSearchTerm] = useState("");
 
   // Callback function to receive what page number user is at on AdCardList.tsx
   const recieveDataFromAdCardListChild = (page: number) => {
@@ -38,7 +39,8 @@ const Home = () => {
     setIsSearching((prevSaved) => !prevSaved);
     setSearchBarText("");
     setCurrentPage(prevPageNumber);
-  }
+    setSearchCount(0);
+  };
 
   // Callback function to know when user request a new search for ads in Header.tsx
   const newSearch = async (event: any) => {
@@ -46,15 +48,17 @@ const Home = () => {
     if (searchBarText === "") return;
     if (currentPage !== 1) {
       setPrevPageNumber(currentPage);
-      setCurrentPage(1);} 
+      setCurrentPage(1);
+    }
     setIsSearching(true);
     setSearchCount(searchCount + 1);
+    setSearchTerm(searchBarText);
   };
 
   const savedAdCounter = () => {
     setAdCounter(adCounter + 1);
     console.log(adCounter);
-  }
+  };
 
   // Fetch total ad count in database
   const fetchAdCount = () => {
@@ -113,7 +117,7 @@ const Home = () => {
                 }}
               >
                 Sparade annonser
-                <SavedAds savedAdCounter={savedAdCounter}/>
+                <SavedAds savedAdCounter={savedAdCounter} />
               </span>
             </Container>
           </Col>
@@ -128,7 +132,8 @@ const Home = () => {
               changeIsSearching={changeIsSearching}
               isLoading={isLoading}
               savedAdCounter={savedAdCounter}
-              searchBarText={searchBarText}
+              searchTerm={searchTerm}
+              searchCount={searchCount}
             />
           </Col>
         </Row>

--- a/src/components/public/Home.tsx
+++ b/src/components/public/Home.tsx
@@ -3,7 +3,6 @@ import { useState, useEffect } from "react";
 import Header from "../common/Header";
 import AdCardList from "../common/AdCardList";
 import { Row, Col, Container } from "react-bootstrap";
-import JobCard from "../common/JobCard";
 import SavedAds from "../common/SavedAds";
 
 const Home = () => {

--- a/src/components/public/Home.tsx
+++ b/src/components/public/Home.tsx
@@ -56,7 +56,6 @@ const Home = () => {
 
   const savedAdCounter = () => {
     setAdCounter(adCounter + 1);
-    console.log(adCounter);
   };
 
   // Fetch total ad count in database
@@ -107,17 +106,18 @@ const Home = () => {
         <Row>
           <Col sm={3} className="SavedAdsContainer">
             <Container style={{ textAlign: "left" }}>
-              <span
+            <span
                 style={{
-                  marginLeft: "0.5rem",
                   color: "gray",
                   cursor: "default",
                   fontSize: "12px",
+                  display: "inline-block",
+                  height: "2rem",
                 }}
               >
                 Sparade annonser
-                <SavedAds savedAdCounter={savedAdCounter} />
               </span>
+              <SavedAds savedAdCounter={savedAdCounter} />
             </Container>
           </Col>
           <Col sm={9} className="LatestAdsContainer">

--- a/src/components/public/Home.tsx
+++ b/src/components/public/Home.tsx
@@ -117,6 +117,7 @@ const Home = () => {
       setIsLoading(false);
     };
     fetchData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentPage, isSearching, searchCount]);
 
   return (


### PR DESCRIPTION
- Fixed a TS compile error as we tried to give pageSize a string while it was init as number when triggering onSelect for dropdown selector
- Moved page size selector on ad page to top
- Enabled page change by pressing specific page
- Made saved ads section beutiful
- Added trash can icon so user can delete saved ad in the saved ad section
- Added more API properties on jobcards
- CSS styling of jobcards
- Can now click on saved ad and see the information in the main section
- Removed TS warnings
- Simple scroll animation to top of page as you request a new page